### PR TITLE
add support for running tool for multiple database types

### DIFF
--- a/src/cosmos-toolbox-app/AppSettings.cs
+++ b/src/cosmos-toolbox-app/AppSettings.cs
@@ -7,7 +7,7 @@ namespace CosmosToolbox.App
     public class AppSettings
     {
         public static Lazy<JsonSerializerSettings> JsonSerializerSettings = 
-            new Lazy<JsonSerializerSettings>(() => GetDefaultSerializerSettings());
+            new Lazy<JsonSerializerSettings>(GetDefaultSerializerSettings);
 
         private static JsonSerializerSettings GetDefaultSerializerSettings()
         {

--- a/src/cosmos-toolbox-app/Data/CosmosClientContext.cs
+++ b/src/cosmos-toolbox-app/Data/CosmosClientContext.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Cosmos.Linq;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using CosmosToolbox.Core.Data;
 using CosmosToolbox.App.Extensions;
 using CosmosToolbox.Core.Options;
@@ -19,9 +18,9 @@ namespace CosmosToolbox.App.Data
         private readonly ClientContextOptions _options;  
         private readonly ILogger _logger;
 
-        public CosmosClientContext(IOptions<ClientContextOptions> options, ILogger<CosmosClientContext> logger)
+        public CosmosClientContext(ClientContextOptions options, ILogger<CosmosClientContext> logger)
         {
-            _options = options?.Value;
+            _options = options;
             _logger = logger;
         }
 

--- a/src/cosmos-toolbox-app/Data/CosmosClientContextFactory.cs
+++ b/src/cosmos-toolbox-app/Data/CosmosClientContextFactory.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using CosmosToolbox.App.Extensions;
+using CosmosToolbox.Core.Data;
+using CosmosToolbox.Core.Enums;
+using CosmosToolbox.Core.Options;
+using Microsoft.Extensions.Logging;
+
+namespace CosmosToolbox.App.Data
+{
+    public sealed class CosmosClientContextFactory : IClientContextFactory, IDisposable
+    {
+        private ConcurrentDictionary<string, IClientContext> _clientContexts;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public CosmosClientContextFactory(ILoggerFactory loggerFactory)
+        {
+            _clientContexts = new ConcurrentDictionary<string, IClientContext>();
+            _loggerFactory = loggerFactory;
+        }
+
+        public IClientContext Create(ClientContextOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            var key = options.GetContextIdentifier();
+            var context = _clientContexts.GetOrAdd(key, CreateContext(options));
+            return context;
+        }
+
+        private IClientContext CreateContext(ClientContextOptions options)
+        {
+            options.Validate();
+
+            if (options.Database.Api.Equals(DatabaseApi.SqlApi))
+                return new CosmosClientContext(options, _loggerFactory.CreateLogger<CosmosClientContext>());
+            else 
+                throw new NotSupportedException($"api '{options.Database.Api}' is not currently supported in {nameof(CosmosClientContextFactory)}");
+        }
+
+        public void Dispose()
+        {
+            if (!(_clientContexts?.Any() ?? false))
+                return;
+
+            foreach (var clientContext in _clientContexts)
+                if(clientContext.Value is IDisposable disposableValue)
+                    disposableValue.Dispose();
+
+            _clientContexts = null;
+        }
+    }
+}

--- a/src/cosmos-toolbox-app/Extensions/OptionsExtensions.cs
+++ b/src/cosmos-toolbox-app/Extensions/OptionsExtensions.cs
@@ -40,7 +40,13 @@ namespace CosmosToolbox.App.Extensions
 
         public static void Validate(this ClientContextOptions options)
         {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
 
+            if (options.Database == null)
+                throw new ArgumentNullException(nameof(options.Database));
+
+            options.Database.Validate();
         }
     }
 }

--- a/src/cosmos-toolbox-app/Options/OptionsService.cs
+++ b/src/cosmos-toolbox-app/Options/OptionsService.cs
@@ -2,6 +2,7 @@ using CosmosToolbox.Core.Options;
 using Newtonsoft.Json;
 using System.IO;
 using System.Threading.Tasks;
+using CosmosToolbox.Core.Enums;
 
 namespace CosmosToolbox.App.Options
 {
@@ -47,6 +48,7 @@ namespace CosmosToolbox.App.Options
                 {
                     Id = "<Database Id>",
                     Throughput = 400,
+                    Api = DatabaseApi.SqlApi,
                     Containers = new [] 
                     {
                         new ContainerOptions

--- a/src/cosmos-toolbox-app/PackageModule.cs
+++ b/src/cosmos-toolbox-app/PackageModule.cs
@@ -11,7 +11,7 @@ namespace CosmosToolbox.App
     {
         public void RegisterServices(IServiceCollection services)
         {
-            services.AddSingleton<IClientContext, CosmosClientContext>();
+            services.AddSingleton<IClientContextFactory, CosmosClientContextFactory>();
             
             services.AddTransient<IOptionsService, OptionsService>();
             services.AddTransient<IAppStrategy, CreateContainersStrategy>();

--- a/src/cosmos-toolbox-app/Strategy/ValidateOptionsStrategy.cs
+++ b/src/cosmos-toolbox-app/Strategy/ValidateOptionsStrategy.cs
@@ -8,10 +8,10 @@ namespace CosmosToolbox.App.Strategy
 {
     public sealed class ValidateOptionsStrategy : IAppStrategy
     {
-        private readonly ClientContextOptions _options;
+        private readonly ClientContextOptionsGroup _options;
         private readonly ILogger _logger;
 
-        public ValidateOptionsStrategy(IOptions<ClientContextOptions> options, ILogger<ValidateOptionsStrategy> logger)
+        public ValidateOptionsStrategy(IOptions<ClientContextOptionsGroup> options, ILogger<ValidateOptionsStrategy> logger)
         {
             _options = options?.Value;
             _logger = logger;
@@ -26,7 +26,13 @@ namespace CosmosToolbox.App.Strategy
 
         public Task RunAsync(IApplicationArgs args)
         {
-            _options.Validate();
+            foreach (var options in _options.Databases)
+            {
+                _logger.LogDebug($"validating options for database {options?.Database.Id}");
+                options.Validate();
+                _logger.LogDebug("options are valid");
+            }
+
             return Task.FromResult(true);
         }
     }

--- a/src/cosmos-toolbox-core/Converters/EnumerationJsonConverter.cs
+++ b/src/cosmos-toolbox-core/Converters/EnumerationJsonConverter.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using CosmosToolbox.Core.Enums;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace CosmosToolbox.Core.Converters
+{
+    public sealed class EnumerationJsonConverter : JsonConverter
+    {
+        public override bool CanRead => true;
+
+        public override bool CanWrite => true;
+
+        public bool NameIsNullable { get; set;  }
+
+        public EnumerationJsonConverter()
+        {
+            NameIsNullable = false;
+        }
+
+        public EnumerationJsonConverter(bool nameIsNullable)
+        {
+            NameIsNullable = nameIsNullable;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                if(!(value is Enumeration enumeration))
+                    throw new JsonSerializationException($"unable to cast type {value.GetType().Name} to type {nameof(Enumeration)}");
+
+                if(!NameIsNullable && enumeration.Name == null)
+                    throw new JsonSerializationException($"{nameof(Enumeration.Name)} cannot be null");
+
+                if (enumeration.Name != null)
+                    writer.WriteValue(enumeration.Name);
+                else
+                    writer.WriteValue(enumeration.Id);
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null || reader.TokenType == JsonToken.None || reader.TokenType == JsonToken.Undefined)
+            {
+                return null;
+            }
+
+            string str = null;
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                var jObject = JObject.Load(reader);
+                if (jObject.TryGetValue(nameof(Enumeration.Name), StringComparison.OrdinalIgnoreCase, out var nameValue))
+                    str = nameValue?.ToString();
+                
+                if (string.IsNullOrEmpty(str) && jObject.TryGetValue(nameof(Enumeration.Id), StringComparison.OrdinalIgnoreCase, out var idValue))
+                    str = idValue?.ToString();
+            }
+            else
+            {
+                str = reader.Value?.ToString();
+            }
+
+            if (!string.IsNullOrEmpty(str) && Enumeration.TryParse(objectType, str, out var enumeration))
+            {
+                return enumeration;
+            }
+
+            throw new JsonSerializationException($"unable to parse value '{str}' for type {objectType.Name}");
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Enumeration)
+                   || typeof(Enumeration).IsAssignableFrom(objectType)
+                   || objectType == typeof(string)
+                   || objectType == typeof(int);
+        }
+    }
+}

--- a/src/cosmos-toolbox-core/Data/IClientContextFactory.cs
+++ b/src/cosmos-toolbox-core/Data/IClientContextFactory.cs
@@ -1,0 +1,9 @@
+﻿using CosmosToolbox.Core.Options;
+
+namespace CosmosToolbox.Core.Data
+{
+    public interface IClientContextFactory
+    {
+        IClientContext Create(ClientContextOptions options);
+    }
+}

--- a/src/cosmos-toolbox-core/Enums/DatabaseApi.cs
+++ b/src/cosmos-toolbox-core/Enums/DatabaseApi.cs
@@ -1,0 +1,21 @@
+﻿using CosmosToolbox.Core.Converters;
+using Newtonsoft.Json;
+
+namespace CosmosToolbox.Core.Enums
+{
+    /// <summary>
+    /// supported database APIs
+    /// </summary>
+    [JsonConverter(typeof(EnumerationJsonConverter))]
+    public sealed class DatabaseApi : Enumeration
+    {
+        public static readonly DatabaseApi SqlApi = new DatabaseApi(1, "sql");
+        public static readonly DatabaseApi MongoDbApi = new DatabaseApi(2, "mongodb");
+        public static readonly DatabaseApi TableApi = new DatabaseApi(3, "table");
+        public static readonly DatabaseApi CassandraApi = new DatabaseApi(4, "cassandra");
+        public static readonly DatabaseApi GremlinApi = new DatabaseApi(5, "gremlin");
+
+        private DatabaseApi(int id, string name) 
+            : base(id, name) { }
+    }
+}

--- a/src/cosmos-toolbox-core/Enums/Enumeration.cs
+++ b/src/cosmos-toolbox-core/Enums/Enumeration.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace CosmosToolbox.Core.Enums
+{
+    public interface IEnumeration
+    {
+        int Id { get;  }
+        string Name { get;  }
+        string DisplayValue { get; }
+    }
+
+    public abstract class Enumeration : IComparable, IEnumeration
+    {
+        public string Name { get; }
+
+        public int Id { get; }
+
+        public string DisplayValue { get; set; }
+
+        protected Enumeration(int id, string name, string displayValue = null)
+        {
+            Id = id;
+            Name = name;
+            DisplayValue = displayValue;
+        }
+
+        public override string ToString() => Name;
+
+        public static T GetById<T>(int id) where T : Enumeration
+        {
+            var enumeration = GetById(typeof(T), id);
+            return CastOrCreate<T>(enumeration);
+        }
+
+        public static Enumeration GetById(Type type, int id)
+        {
+            var allEnumerations = GetAll(type);
+            var enumerationById = allEnumerations.SingleOrDefault(p => p.Id == id);
+            return enumerationById;
+        }
+
+        public static T GetByName<T>(string name, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
+            where T : Enumeration
+        {
+            var enumeration = GetByName(typeof(T), name);
+            return CastOrCreate<T>(enumeration);
+        }
+
+        public static Enumeration GetByName(Type type, string name, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
+        {
+            if (name == null)
+                throw new ArgumentNullException(nameof(name));
+
+            var allEnumerations = GetAll(type);
+            var enumerationByName = allEnumerations
+                .SingleOrDefault(p => 
+                    string.Equals(p.Name, name, comparisonType));
+
+            return enumerationByName;
+        }
+
+        public static IEnumerable<T> GetAll<T>() where T : Enumeration
+        {
+            var genericType = typeof(T);
+            var enumerations = GetAll(genericType);
+            return enumerations.Select(CastOrCreate<T>);
+        }
+
+        public static IEnumerable<Enumeration> GetAll(Type type)
+        {
+            var fields = type.GetFields(BindingFlags.Public
+                                        | BindingFlags.Static
+                                        | BindingFlags.DeclaredOnly);
+
+            var enumerationFields = fields
+                .Select(f => f.GetValue(null))
+                .Cast<Enumeration>();
+
+            var allEnumerations = (
+                    type.BaseType != null && !type.IsAbstract
+                        ? enumerationFields.Union(GetAll(type.BaseType))
+                        : enumerationFields)
+                .OrderBy(o => o.Id)
+                .ToList();
+
+            return allEnumerations;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Enumeration otherValue))
+                return false;
+
+            var typeMatches = GetType() == obj.GetType();
+            var valueMatches = Id.Equals(otherValue.Id);
+
+            return typeMatches && valueMatches;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ Id;
+            }
+        }
+
+        public int CompareTo(object other) => Id.CompareTo(((Enumeration)other).Id);
+
+        public static bool TryParse<T>(string value, out T enumeration) where T : Enumeration
+        {
+            if (TryParse(typeof(T), value, out var valueEnumeration))
+            {
+                enumeration = CastOrCreate<T>(valueEnumeration);
+                return true;
+            }
+            else
+            {
+                enumeration = null;
+                return false;
+            }
+        }
+
+        public static bool TryParse(Type type, string value, out Enumeration enumeration) 
+        {
+            enumeration = null;
+
+            if (value == null)
+            {
+                return false;
+            }
+
+            if (int.TryParse(value, out var intValue))
+            {
+                enumeration = GetById(type, intValue);
+            }
+
+            enumeration ??= GetByName(type, value);
+
+            return enumeration != null;
+        }
+
+        private static T CastOrCreate<T>(IEnumeration enumeration)
+        {
+            var genericType = typeof(T);
+            if (genericType == enumeration.GetType())
+            {
+                return (T) enumeration;
+            }
+
+            var argTypes = new[]
+            {
+                typeof(int),
+                typeof(string),
+                typeof(string)
+            };
+            
+            var constructor = genericType.GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Instance, 
+                null, 
+                argTypes, 
+                null);
+
+            var argValues = new object[]
+            {
+                enumeration.Id,
+                enumeration.Name,
+                enumeration.DisplayValue
+            };
+
+            return (T)constructor?.Invoke(argValues);
+        }
+
+    }
+}

--- a/src/cosmos-toolbox-core/Options/ClientContextOptions.cs
+++ b/src/cosmos-toolbox-core/Options/ClientContextOptions.cs
@@ -1,7 +1,13 @@
 using System;
+using System.Collections.Generic;
 
 namespace CosmosToolbox.Core.Options
 {
+    public sealed class ClientContextOptionsGroup
+    {
+        public IEnumerable<ClientContextOptions> Databases { get; set; }
+    }
+
     public sealed class ClientContextOptions
     {
         public DatabaseOptions Database { get; set; }
@@ -17,5 +23,10 @@ namespace CosmosToolbox.Core.Options
 
         public TimeSpan? MaxRetryWaitTimeOnThrottledRequests { get; set; } 
         public int? MaxRetryAttemptsOnThrottledRequests { get; set; }
+
+        public string GetContextIdentifier()
+        {
+            return $"{Database?.Id}_{EndpointUri}";
+        }
     }
 }

--- a/src/cosmos-toolbox-core/Options/DatabaseOptions.cs
+++ b/src/cosmos-toolbox-core/Options/DatabaseOptions.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CosmosToolbox.Core.Enums;
 
 namespace CosmosToolbox.Core.Options
 {
@@ -14,15 +18,41 @@ namespace CosmosToolbox.Core.Options
         public string Id { get; set; }
 
         /// <summary>
-        /// specify a value to set shared throughput at datbase level
+        /// specify a value to set shared throughput at database level
         /// </summary>
         /// <value></value>
         public int? Throughput { get; set; }
+
+        /// <summary>
+        /// database api associated with this database (defaults to SQL)
+        /// </summary>
+        public DatabaseApi Api { get; set; } = DatabaseApi.SqlApi;
 
         /// <summary>
         /// any containers to be created within this database
         /// </summary>
         /// <value></value>
         public IEnumerable<ContainerOptions> Containers { get; set; }
+
+        /// <summary>
+        /// validates configuration is correct
+        /// </summary>
+        public void Validate()
+        {
+            var sbErrors = new StringBuilder();
+
+            if (string.IsNullOrEmpty(Id))
+                sbErrors.Append($"{nameof(Id)} was null or empty");
+
+            if (Api == null)
+                sbErrors.Append($"{nameof(Api)} was null or empty");
+
+            if (!(Containers?.Any() ?? false))
+                sbErrors.Append($"no {nameof(Containers)} were specified");
+
+            var errors = sbErrors.ToString();
+            if (!string.IsNullOrEmpty(errors))
+                throw new ArgumentException($"{nameof(DatabaseOptions)} Errors: {errors}");
+        }
     }
 }

--- a/src/cosmos-toolbox/AppServicesProvider.cs
+++ b/src/cosmos-toolbox/AppServicesProvider.cs
@@ -54,7 +54,7 @@ namespace CosmosToolbox
                 logging.AddConsole();
             });
 
-            collection.AddOptions<ClientContextOptions>()
+            collection.AddOptions<ClientContextOptionsGroup>()
                 .Bind(_configuration.GetSection("CosmosDb"));
 
             var modules = new IPackageModule[]

--- a/src/cosmos-toolbox/appsettings.json
+++ b/src/cosmos-toolbox/appsettings.json
@@ -1,12 +1,14 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft": "Warning",
-            "Microsoft.Hosting.Lifetime": "Information"
-        }
-    },
-    "CosmosDb": {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "CosmosDb": {
+    "Databases": [
+      {
         "EndpointUri": "https://localhost:8081",
         "PrimaryKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
         "ConsistencyLevel": null,
@@ -15,12 +17,17 @@
         "MaxRetryAttemptsOnThrottledRequests": 5,
         "CamelCasePropertyNames": true,
         "Database": {
-            "Id": "Sandbox",
-            "Throughput": 1000,
-            "Containers": [{
-                "Id": "Container1",
-                "PartitionKey": "/TestKey"
-            }]
+          "Id": "Sandbox",
+          "Throughput": 1000,
+          "Api": "sql",
+          "Containers": [
+            {
+              "Id": "Container1",
+              "PartitionKey": "/TestKey"
+            }
+          ]
         }
-    }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
closes #15 

* add support to specify multiple databases in config and process each one
* add clientcontextfactory to support multiple api types
* add Api and validation to DatabaseOptions
* add DatabaseApi enum class
* add Enumeration base class to implement enums as classes 
* add converter for serialize/deserialize any enums as classes implementations