### PR TITLE
Creating Unit Test Branch and fixing Nuget issue

### DIFF
--- a/src/CosmosToolbox.sln
+++ b/src/CosmosToolbox.sln
@@ -1,15 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cosmos-toolbox", "cosmos-toolbox\cosmos-toolbox.csproj", "{2B6B645F-F4B5-4506-B5FB-308292D5CFA4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cosmos-toolbox", "cosmos-toolbox\cosmos-toolbox.csproj", "{2B6B645F-F4B5-4506-B5FB-308292D5CFA4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cosmos-toolbox-core", "cosmos-toolbox-core\cosmos-toolbox-core.csproj", "{444383EC-0226-4478-A0A4-F8B6D62AE7A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cosmos-toolbox-core", "cosmos-toolbox-core\cosmos-toolbox-core.csproj", "{444383EC-0226-4478-A0A4-F8B6D62AE7A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cosmos-toolbox-app", "cosmos-toolbox-app\cosmos-toolbox-app.csproj", "{C64FFEA7-2540-43E3-B437-C758B740842D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cosmos-toolbox-app", "cosmos-toolbox-app\cosmos-toolbox-app.csproj", "{C64FFEA7-2540-43E3-B437-C758B740842D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cosmos-toolbox-tests", "..\tests\cosmos-toolbox-tests\cosmos-toolbox-tests.csproj", "{BE2382D8-B67D-4209-8806-84C3DDAB3BDC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cosmos-toolbox-tests", "..\tests\cosmos-toolbox-tests\cosmos-toolbox-tests.csproj", "{BE2382D8-B67D-4209-8806-84C3DDAB3BDC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cosmos-toolbox-app-tests", "cosmos-toolbox-app-tests\cosmos-toolbox-app-tests.csproj", "{FBC30F09-1E86-4389-B46E-C434DF52C9E5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2B6B645F-F4B5-4506-B5FB-308292D5CFA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -72,5 +71,23 @@ Global
 		{BE2382D8-B67D-4209-8806-84C3DDAB3BDC}.Release|x64.Build.0 = Release|Any CPU
 		{BE2382D8-B67D-4209-8806-84C3DDAB3BDC}.Release|x86.ActiveCfg = Release|Any CPU
 		{BE2382D8-B67D-4209-8806-84C3DDAB3BDC}.Release|x86.Build.0 = Release|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Debug|x64.Build.0 = Debug|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Debug|x86.Build.0 = Debug|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Release|x64.ActiveCfg = Release|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Release|x64.Build.0 = Release|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Release|x86.ActiveCfg = Release|Any CPU
+		{FBC30F09-1E86-4389-B46E-C434DF52C9E5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {46EE38B6-CE17-4CF3-82D6-D5B40BAAADCE}
 	EndGlobalSection
 EndGlobal

--- a/src/cosmos-toolbox-app-tests/Strategy/CreateContainersStrategyTests.cs
+++ b/src/cosmos-toolbox-app-tests/Strategy/CreateContainersStrategyTests.cs
@@ -1,0 +1,67 @@
+﻿using CosmosToolbox.Core.Data;
+using CosmosToolbox.Core.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace CosmosToolbox.App.Strategy.Tests
+{
+    [TestClass()]
+    public class CreateContainersStrategyTests
+    {
+        private ClientContextOptionsGroup testClientContextOptionsgroup;
+
+        private CreateContainersStrategy testCreateContainersStrategy;
+
+        private readonly Mock<IClientContextFactory> mockClientContextFactory = new Mock<IClientContextFactory>();
+
+        private readonly Mock<ILogger<CreateContainersStrategy>> mockLogger = new Mock<ILogger<CreateContainersStrategy>>();
+
+        private readonly Mock<IApplicationArgs> mockApplicationArgs = new Mock<IApplicationArgs>();
+
+        private readonly Mock<IOptions<ClientContextOptionsGroup>> mockOptions = new Mock<IOptions<ClientContextOptionsGroup>>();
+
+        [TestInitialize]
+        public void Startup()
+        {
+            testCreateContainersStrategy = new CreateContainersStrategy(mockOptions.Object, mockClientContextFactory.Object, mockLogger.Object);
+        }
+
+        [TestMethod]
+        [DataRow(true, true, true, "Should be true when IApplicationArgs carries CreateDatabase and CreateContainers")]
+        [DataRow(false, true, true, "Should be true when IApplicationArgs carries at least CreateContainers")]
+        [DataRow(false, false, false, "Should be false when IApplicationArgs does not carry CreateCDatabase or CreateContainers")]
+        [DataRow(true, false, true, "Should be true when IApplicationArgs carries at least CreateDatabase")]
+        public void IsApplicableTest(bool createDatabase, bool createContainers, bool expectedResult, string message)
+        {
+            // Arrange
+            mockApplicationArgs.Setup(m => m.CreateDatabase).Returns(createDatabase);
+            mockApplicationArgs.Setup(m => m.CreateContainers).Returns(createContainers);
+
+            // Act
+            bool actualResult = testCreateContainersStrategy.IsApplicable(mockApplicationArgs.Object);
+
+            // Assert
+            Assert.AreEqual(expectedResult, actualResult, message);
+        }
+
+        [TestMethod]
+        [DataRow(true, true, false, "Shouldn't be false when IApplicationArgs carries CreateDatabase and CreateContainers")]
+        [DataRow(false, true, false, "Shouldn't be false when IApplicationArgs carries at least CreateContainers")]
+        [DataRow(false, false, true, "Shouldn't be true when IApplicationArgs does not carry CreateCDatabase or CreateContainers")]
+        [DataRow(true, false, false, "Shouldn't be false when IApplicationArgs carries at least CreateDatabase")]
+        public void IsNotApplicableTest(bool createDatabase, bool createContainers, bool expectedResult, string message)
+        {
+            // Arrange
+            mockApplicationArgs.Setup(m => m.CreateDatabase).Returns(createDatabase);
+            mockApplicationArgs.Setup(m => m.CreateContainers).Returns(createContainers);
+
+            // Act
+            bool actualResult = testCreateContainersStrategy.IsApplicable(mockApplicationArgs.Object);
+
+            // Assert
+            Assert.AreNotEqual(expectedResult, actualResult, message);
+        }
+    }
+}

--- a/src/cosmos-toolbox-app-tests/cosmos-toolbox-app-tests.csproj
+++ b/src/cosmos-toolbox-app-tests/cosmos-toolbox-app-tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>cosmos_toolbox_app_tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\cosmos-toolbox-app\cosmos-toolbox-app.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/cosmos-toolbox-app/cosmos-toolbox-app.csproj
+++ b/src/cosmos-toolbox-app/cosmos-toolbox-app.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.12.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.15.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />


### PR DESCRIPTION
- Creating Unit Test Branch.
- Updating cosmos-toolbox-app.csproj's Microsoft.Azure.Cosmos nuget to 3.15 because 3.12 throws an error asking us to add a reference to directly consume Microsoft.Azure.Cosmos.Direct—which is a no-no. 3.15 is the earliest version that resolves it and I didn't know how current the Nuget packages should be.
- Created cosmos-toolbox-app-tests.csproj to house unit tests.
- Created CreateContainersStrategyTests class
- Added basic unit tests in MSTest for IsValid method in CreateContainersStrategy.cs